### PR TITLE
Branch predictor support for Pak-RV

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,6 +50,7 @@ jobs:
 
         pip3 install cocotb
         pip3 install git+https://github.com/riscv/riscof.git
+        pip3 install --upgrade riscv_isac
 
     - name: Setup RISC-V GNU toolchain
       run: |

--- a/.gitignore
+++ b/.gitignore
@@ -20,4 +20,5 @@ pakrv_dump.vcd
 
 #test build dir
 obj/
+verilator_sim/
 

--- a/include/ex_stage_pkg.svh
+++ b/include/ex_stage_pkg.svh
@@ -34,6 +34,13 @@
             logic        opr_a_sel;
             logic        opr_b_sel;
             logic [ 1:0] wb_sel;
+
+            // from branch predictor
+            logic        is_conditional_branch;
+            logic        is_jalr;
+            logic        is_jal;
+            logic        predict_taken;
+            logic [31:0] predict_pc;
         } ex_stage_in_t;
 
         typedef struct packed
@@ -41,6 +48,8 @@
             logic        rf_en;
             logic [ 4:0] rd;
             logic [31:0] opr_res;
+            logic [31:0] pc4;
+            logic        is_jal;
         } ex_stage_in_frm_mem_t;
 
         typedef struct packed
@@ -66,6 +75,7 @@
             logic               dm_en;
             logic               csr_wr_en;
             logic        [ 1:0] wb_sel;
+            logic               is_jal;
         } ex_stage_out_t;
 
         typedef struct packed 

--- a/include/id_stage_pkg.svh
+++ b/include/id_stage_pkg.svh
@@ -21,6 +21,11 @@
             logic [31:0] inst;
             logic [31:0] pc;
             logic [31:0] pc4;
+            logic        is_conditional_branch;
+            logic        is_jalr;
+            logic        is_jal;
+            logic        predict_taken;
+            logic [31:0] predict_pc;
         } id_stage_in_t;
 
         typedef struct packed
@@ -51,6 +56,13 @@
             logic        opr_a_sel;
             logic        opr_b_sel;
             logic [ 1:0] wb_sel;
+
+            // for branch predictor
+            logic        is_conditional_branch;
+            logic        is_jalr;
+            logic        is_jal;
+            logic        predict_taken;
+            logic [31:0] predict_pc;
         } id_stage_out_t;
 
         typedef struct packed

--- a/include/if_stage_pkg.svh
+++ b/include/if_stage_pkg.svh
@@ -8,6 +8,7 @@
         {
             logic               br_taken;
             logic signed [31:0] br_target;
+            logic               misprediction; // active high signal, for branch prediction unit
             logic               stall;
         } if_stage_in_t;
 

--- a/include/if_stage_pkg.svh
+++ b/include/if_stage_pkg.svh
@@ -17,7 +17,18 @@
             logic [31:0] inst;
             logic [31:0] pc;
             logic [31:0] pc4;
+            logic        is_conditional_branch;
+            logic        is_jalr;
+            logic        is_jal;
+            logic        predict_taken;
+            logic [31:0] predict_pc;
         } if_stage_out_t;
+
+        typedef struct packed 
+        {
+            logic        br_taken;
+            logic [31:0] br_target;
+        } if_stage_in_frm_ex_t;
 
     endpackage
 

--- a/include/if_stage_pkg.svh
+++ b/include/if_stage_pkg.svh
@@ -6,6 +6,7 @@
 
         typedef struct packed 
         {
+            logic        [31:0] instruction;
             logic               br_taken;
             logic signed [31:0] br_target;
             logic               misprediction; // active high signal, for branch prediction unit
@@ -24,12 +25,6 @@
             logic        predict_taken;
             logic [31:0] predict_pc;
         } if_stage_out_t;
-
-        typedef struct packed 
-        {
-            logic        br_taken;
-            logic [31:0] br_target;
-        } if_stage_in_frm_ex_t;
 
     endpackage
 

--- a/include/mem_stage_pkg.svh
+++ b/include/mem_stage_pkg.svh
@@ -26,6 +26,7 @@
             logic               dm_en;
             logic               csr_wr_en;
             logic        [ 1:0] wb_sel;
+            logic               is_jal;
         } mem_stage_in_t;
 
         typedef struct packed 

--- a/src/core.sv
+++ b/src/core.sv
@@ -66,7 +66,7 @@ module core
     ex_stage_in_frm_mem_t ex_stage_in_frm_mem;
     ex_stage_in_frm_wb_t  ex_stage_in_frm_wb;
     if_stage_in_frm_ex_t  if_stage_in_frm_ex;
-    logic                 misprediction;
+    logic                 misprediction_frm_ex;
 
     logic [DATA_WIDTH-1:0] pc4;
 
@@ -84,7 +84,6 @@ module core
         .inst_in       (inst_in      ),
         .if_stage_in   (if_stage_in  ),
         .if_stage_in_frm_ex(if_stage_in_frm_ex),
-        .misprediction ( misprediction   ),
         .if_stage_out  (/*if_stage_out*/ ),
         .is_conditional_branch ( if_stage_out.is_conditional_branch ),
         .is_jalr               ( if_stage_out.is_jalr               ),
@@ -118,7 +117,7 @@ module core
         .ex_stage_in_frm_mem(ex_stage_in_frm_mem),
         .ex_stage_in_frm_wb (ex_stage_in_frm_wb ),
         .ex_stage_out       (ex_stage_out       ),
-        .misprediction      (misprediction      ),
+        .misprediction      (misprediction_frm_ex),
         .ex_cfu_out         (ex_cfu_out         )
     );
 
@@ -155,6 +154,7 @@ module core
     begin
         if_stage_in.br_taken        = ex_cfu_out.br_taken;
         if_stage_in.br_target       = ex_cfu_out.br_target;
+        if_stage_in.misprediction   = misprediction_frm_ex;
         if_stage_in.stall           = id_hdu_out.stall;
         ex_stage_in_frm_mem.rf_en   = mem_stage_in.rf_en;
         ex_stage_in_frm_mem.rd      = mem_stage_in.rd;
@@ -171,7 +171,7 @@ module core
     // if -> id
     always_ff @(posedge clk or negedge arst_n) 
     begin
-        if (~arst_n | misprediction) 
+        if (~arst_n | misprediction_frm_ex) 
         begin
             id_stage_in  <= '0;
         end
@@ -184,7 +184,7 @@ module core
     // id -> ex
     always_ff @(posedge clk or negedge arst_n) 
     begin
-        if (~arst_n | id_hdu_out.flush | misprediction) 
+        if (~arst_n | id_hdu_out.flush | misprediction_frm_ex) 
         begin
             ex_stage_in  <= '0;
         end

--- a/src/core.sv
+++ b/src/core.sv
@@ -26,9 +26,10 @@ module core
 
     import if_stage_pkg ::if_stage_in_frm_ex_t;
 # (
-    parameter  DATA_WIDTH    = 32,
-    parameter  IMEM_SZ_IN_KB = 1,
-    parameter  DMEM_SZ_IN_KB = 1
+    parameter  DATA_WIDTH                = 32,
+    parameter  IMEM_SZ_IN_KB             = 1,
+    parameter  DMEM_SZ_IN_KB             = 1,
+    parameter  SUPPORT_BRANCH_PREDICTION = 1
 ) (
     input  logic                    clk,
     input  logic                    arst_n,
@@ -74,8 +75,9 @@ module core
 
     // stage instantiations
     if_stage # (
-        .DATA_WIDTH    (DATA_WIDTH   ),
-        .IMEM_SZ_IN_KB (IMEM_SZ_IN_KB)
+        .DATA_WIDTH                ( DATA_WIDTH                ),
+        .IMEM_SZ_IN_KB             ( IMEM_SZ_IN_KB             ),
+        .SUPPORT_BRANCH_PREDICTION ( SUPPORT_BRANCH_PREDICTION )
     ) i_if_stage (
         .clk           (clk          ),
         .arst_n        (arst_n       ),

--- a/src/core_top.sv
+++ b/src/core_top.sv
@@ -1,8 +1,9 @@
 // core_top contains core's pipeline and memory
 
 module core_top # (
-    parameter DATA_WIDTH = 32,
-    parameter ADDR_WIDTH = 32
+    parameter DATA_WIDTH                = 32,
+    parameter ADDR_WIDTH                = 32,
+    parameter SUPPORT_BRANCH_PREDICTION = 1
 )(
     input logic clk,
     input logic arst_n
@@ -18,7 +19,8 @@ module core_top # (
     logic [DATA_WIDTH-1:0] instruction;
 
     core # (
-        .DATA_WIDTH           (DATA_WIDTH  )
+        .DATA_WIDTH                ( DATA_WIDTH                ),
+        .SUPPORT_BRANCH_PREDICTION ( SUPPORT_BRANCH_PREDICTION )
     ) i_core (
         .clk                  (clk         ),
         .arst_n               (arst_n      ),

--- a/src/ex_stage.sv
+++ b/src/ex_stage.sv
@@ -11,12 +11,14 @@ module ex_stage
     import ex_stage_pkg::ex_cfu_out_t;
     import alu_pkg     ::aluop_t;
 # (
-    parameter DATA_WIDTH = 32
+    parameter DATA_WIDTH = 32,
+    parameter SUPPORT_BRANCH_PREDICTION = 1
 ) (
     input  ex_stage_in_t         ex_stage_in,
     input  ex_stage_in_frm_mem_t ex_stage_in_frm_mem,
     input  ex_stage_in_frm_wb_t  ex_stage_in_frm_wb,
     output ex_stage_out_t        ex_stage_out,
+    output logic                 misprediction,
     output ex_cfu_out_t          ex_cfu_out
 );
 
@@ -47,14 +49,29 @@ module ex_stage
     begin
         case(for_a)
             2'b00:   for_opr_a = ex_stage_in.opr_a;
-            2'b01:   for_opr_a = ex_stage_in_frm_mem.opr_res;
-            2'b10:   for_opr_a = ex_stage_in_frm_wb.wb_data;
+
+            /*
+            - for the following case:
+            
+            jal x21, 0x8000_0184
+            addi x21, x21, 1
+
+            - This is the case of clear forwarding, what to forward? Forwarding unit forwards opr_res, but
+               here we need to forward pc4, so need add another check
+
+            - rd != 0 is is the case where we don't need return address like the following case:
+            jal x0, 0x8000_0184
+            addi x21, x21, 1
+            */
+            2'b01:   for_opr_a = (ex_stage_in_frm_mem.is_jal && (ex_stage_in_frm_mem.rd != '0)) ? ex_stage_in_frm_mem.pc4 : ex_stage_in_frm_mem.opr_res;
+
+            2'b10:   for_opr_a = (ex_stage_in_frm_mem.is_jal && (ex_stage_in_frm_mem.rd != '0)) ? ex_stage_in_frm_mem.pc4 : ex_stage_in_frm_wb.wb_data;
             default: for_opr_a = 'b0;
         endcase
         case(for_b)
             2'b00:   for_opr_b = ex_stage_in.opr_b;
-            2'b01:   for_opr_b = ex_stage_in_frm_mem.opr_res;
-            2'b10:   for_opr_b = ex_stage_in_frm_wb.wb_data;
+            2'b01:   for_opr_b = (ex_stage_in_frm_mem.is_jal && (ex_stage_in_frm_mem.rd != '0)) ? ex_stage_in_frm_mem.pc4 : ex_stage_in_frm_mem.opr_res;
+            2'b10:   for_opr_b = (ex_stage_in_frm_mem.is_jal && (ex_stage_in_frm_mem.rd != '0)) ? ex_stage_in_frm_mem.pc4 : ex_stage_in_frm_wb.wb_data;
             default: for_opr_b = 'b0;
         endcase
     end
@@ -81,6 +98,26 @@ module ex_stage
         .br_taken  (ex_cfu_out.br_taken)
     );
 
+    generate
+        if (SUPPORT_BRANCH_PREDICTION == 1)
+        begin
+            // flushing logic in case of misprediction from branch prediction
+            // unconditional branches will not have any misprediction, so exclude them
+            always_comb
+            begin
+                if (ex_stage_in.is_conditional_branch | ex_stage_in.is_jalr)
+                begin
+                    if ((ex_stage_in.predict_taken & ex_cfu_out.br_taken) && (ex_stage_in.predict_pc != ex_cfu_out.br_target)) misprediction = 1'b1; // even if predict_taken and br_taken are 1, we need to check if the predicted pc was same as actual bracnch target
+                    else misprediction = ex_stage_in.predict_taken ^ ex_cfu_out.br_taken;
+                end
+                else
+                begin
+                    misprediction = ex_stage_in.predict_taken ^ ex_cfu_out.br_taken;
+                end
+            end
+        end
+    endgenerate
+
     // propagate signals to next stage
     assign ex_stage_out.opr_res = opr_res;
     assign ex_stage_out.opr_a   = for_opr_a;
@@ -96,6 +133,7 @@ module ex_stage
     assign ex_stage_out.lsuop   = ex_stage_in.lsuop;
     assign ex_stage_out.csrop   = ex_stage_in.csrop;
 
+    assign ex_stage_out.is_jal  = ex_stage_in.is_jal;
     // combinational signals
     assign ex_cfu_out.br_target = opr_res;
 

--- a/src/id_stage.sv
+++ b/src/id_stage.sv
@@ -92,4 +92,10 @@ module id_stage
     assign id_stage_out.pc  = id_stage_in.pc;
     assign id_stage_out.pc4 = id_stage_in.pc4;
 
+    assign id_stage_out.is_conditional_branch = id_stage_in.is_conditional_branch;
+    assign id_stage_out.is_jalr               = id_stage_in.is_jalr;
+    assign id_stage_out.is_jal                = id_stage_in.is_jal;
+    assign id_stage_out.predict_taken         = id_stage_in.predict_taken;
+    assign id_stage_out.predict_pc            = id_stage_in.predict_pc;
+
 endmodule

--- a/src/if_stage.sv
+++ b/src/if_stage.sv
@@ -5,22 +5,104 @@
 module if_stage 
     import if_stage_pkg::if_stage_out_t;
     import if_stage_pkg::if_stage_in_t;
+    import if_stage_pkg::if_stage_in_frm_ex_t;
 # (
     parameter  DATA_WIDTH    = 32,
     parameter  IMEM_SZ_IN_KB = 1,
+    parameter  SUPPORT_BRANCH_PREDICTION = 1,
     localparam PC_SIZE       = 32
 ) (
     input  logic          clk,
     input  logic          arst_n,
+    input  logic [31:0]   inst_in,
     input  if_stage_in_t  if_stage_in,
+    input  if_stage_in_frm_ex_t if_stage_in_frm_ex,
+    input  logic          misprediction,
     output if_stage_out_t if_stage_out,
+    output logic          predict_taken,
+    output logic          is_conditional_branch,
+    output logic          is_jalr,
+    output logic          is_jal,
+    output logic [DATA_WIDTH-1:0] predict_pc,
     output logic [DATA_WIDTH-1:0] pc_out,
     output logic [DATA_WIDTH-1:0] pc4
 );
 
     logic [   PC_SIZE-1:0] pc_in;    
     assign pc4   = pc_out + 'd4;
-    assign pc_in = if_stage_in.br_taken ? if_stage_in.br_target : pc4;
+
+    logic [DATA_WIDTH-1:0] pc_coditional_branch;
+    logic                  is_jalr_d, is_jalr_dd;
+
+    generate
+        if (SUPPORT_BRANCH_PREDICTION == 1)
+        begin: syncing_signals_for_bpu
+
+            logic predict_taken_d, predict_taken_dd;
+            logic is_conditional_branch_d, is_conditional_branch_dd;
+
+            always_ff @ (posedge clk, negedge arst_n)
+            begin
+                if (~arst_n | misprediction)
+                begin
+                    predict_taken_d <= 1'b0;
+                    predict_taken_dd <= 1'b0;            
+                end
+                else if (~if_stage_in.stall)
+                begin
+                    predict_taken_d <= predict_taken;
+                    predict_taken_dd <= predict_taken_d;
+                end
+            end
+
+
+            always_ff @ (posedge clk, negedge arst_n)
+            begin
+                if (~arst_n | misprediction)
+                begin
+                    is_conditional_branch_d  <= 1'b0;
+                    is_conditional_branch_dd <= 1'b0;
+                    is_jalr_d                <= 1'b0;
+                    is_jalr_dd               <= 1'b0;
+                end
+                else if (~if_stage_in.stall)
+                begin
+                    is_conditional_branch_d  <= is_conditional_branch;
+                    is_conditional_branch_dd <= is_conditional_branch_d;
+                    is_jalr_d                <= is_jalr;
+                    is_jalr_dd               <= is_jalr_d;
+                end
+            end
+
+            always_comb
+            begin
+                if (is_conditional_branch_dd | is_jalr_dd)
+                begin
+                    if      ( if_stage_in_frm_ex.br_taken)                                        pc_in = if_stage_in.br_target;
+                    else if (!if_stage_in_frm_ex.br_taken &&  predict_taken_dd)                   pc_in = pc_coditional_branch + 32'd4;
+                    else if (!if_stage_in_frm_ex.br_taken && !predict_taken_dd && !predict_taken) pc_in = pc4; // ~ predict taken handles hazards of conditional branch followed by conditional or unconditional branches
+                    else                                                                          pc_in = predict_pc;
+                end
+                else if (predict_taken)
+                begin
+                    pc_in = predict_pc;
+                end
+                else if (is_jalr_dd)
+                begin
+                    pc_in = if_stage_in.br_target;
+                end
+                else
+                begin
+                    pc_in = pc4;
+                end
+            end
+        end
+
+        else
+        begin
+            assign pc_in = if_stage_in.br_taken ? if_stage_in.br_target : pc4;
+        end
+    endgenerate
 
     pc # (
         .PC_SIZE(PC_SIZE)
@@ -31,5 +113,27 @@ module if_stage
         .pc_in  (pc_in             ),
         .pc_out (pc_out            )
     );
-    
+
+    generate
+        if (SUPPORT_BRANCH_PREDICTION == 1)
+        begin: BPU
+            bpu #(
+                .DATA_WIDTH            ( DATA_WIDTH                   ),
+                .BHT_BTB_SIZE          ( 32                           )
+            ) i_bpu (
+                .clk                   ( clk                          ),
+                .arst_n                ( arst_n                       ),
+                .pc                    ( pc_out                       ),
+                .inst_in               ( inst_in                      ),
+                .br_taken              ( if_stage_in_frm_ex.br_taken  ),
+                .br_target             ( if_stage_in_frm_ex.br_target ),
+                .predict_taken         ( predict_taken                ),
+                .is_conditional_branch ( is_conditional_branch        ),
+                .is_jalr               ( is_jalr                      ),
+                .is_jal                ( is_jal                       ),
+                .pc_reg                ( pc_coditional_branch         ),
+                .predict_pc            ( predict_pc                   )
+            );
+        end
+    endgenerate
 endmodule

--- a/src/if_stage.sv
+++ b/src/if_stage.sv
@@ -17,7 +17,6 @@ module if_stage
     input  logic [31:0]   inst_in,
     input  if_stage_in_t  if_stage_in,
     input  if_stage_in_frm_ex_t if_stage_in_frm_ex,
-    input  logic          misprediction,
     output if_stage_out_t if_stage_out,
     output logic          predict_taken,
     output logic          is_conditional_branch,
@@ -43,7 +42,7 @@ module if_stage
 
             always_ff @ (posedge clk, negedge arst_n)
             begin
-                if (~arst_n | misprediction)
+                if (~arst_n | if_stage_in.misprediction)
                 begin
                     predict_taken_d <= 1'b0;
                     predict_taken_dd <= 1'b0;            
@@ -58,7 +57,7 @@ module if_stage
 
             always_ff @ (posedge clk, negedge arst_n)
             begin
-                if (~arst_n | misprediction)
+                if (~arst_n | if_stage_in.misprediction)
                 begin
                     is_conditional_branch_d  <= 1'b0;
                     is_conditional_branch_dd <= 1'b0;

--- a/sub/components/include/bpu_pkg.svh
+++ b/sub/components/include/bpu_pkg.svh
@@ -1,0 +1,18 @@
+
+`ifndef BPU_PKG_SVH
+
+`define BPU_PKG_SVH
+
+    package bpu_pkg;
+
+        typedef enum logic[1:0] 
+        {  
+            WEAKLY_TAKEN,
+            STRONGLY_TAKEN,
+            WEAKLY_NOT_TAKEN,
+            STRONGLY_NOT_TAKEN
+        } state_t;
+        
+    endpackage
+
+`endif

--- a/sub/components/src/bpu.sv
+++ b/sub/components/src/bpu.sv
@@ -1,0 +1,155 @@
+
+// branch prediction unit
+
+`include "riscv.svh"
+`include "bpu_pkg.svh"
+
+`define RESET_PC 32'h8000_0000
+
+module bpu
+    import bpu_pkg::WEAKLY_TAKEN;
+    import bpu_pkg::STRONGLY_TAKEN;
+    import bpu_pkg::WEAKLY_NOT_TAKEN;
+    import bpu_pkg::STRONGLY_NOT_TAKEN;
+#(
+    parameter DATA_WIDTH = 32,
+    parameter BHT_BTB_SIZE = 32
+)(
+    input  logic                  clk,
+    input  logic                  arst_n,
+    input  logic [DATA_WIDTH-1:0] pc,            // PC reg operating in fetch stage, for BHT and BTB addressing
+    input  logic [DATA_WIDTH-1:0] inst_in,       // instruction input, for pre-decode of branch, jal and jalr
+    input  logic                  br_taken,      // actual branch taken signal, prodcued by EXECUTE stage || Active high
+    input  logic [DATA_WIDTH-1:0] br_target,     // actual branch target signal, prodcued by EXECUTE stage || contains PC where to go
+    output logic                  predict_taken,
+    output logic                  is_conditional_branch,
+    output logic                  is_jalr,
+    output logic                  is_jal,
+    output logic [DATA_WIDTH-1:0] pc_reg,
+    output logic [DATA_WIDTH-1:0] predict_pc
+);
+
+    localparam ADDR_WIDTH = $clog2(BHT_BTB_SIZE);       // number of bits required for the address
+
+    logic [6:0] opcode;
+    // logic       is_conditional_branch;    // check whether it's a branch instruction
+
+    logic       is_branch_d;              // for sync with br_taken
+    logic       is_branch_dd;             // for sync with br_taken
+
+    assign opcode                = inst_in[6:0];
+    assign is_conditional_branch = (opcode == `OPCODE_BRANCH);
+    assign is_jal                = (opcode == `OPCODE_JAL);
+    assign is_jalr               = (opcode == `OPCODE_JALR);
+
+    logic                  bht_btb_valid     [0:BHT_BTB_SIZE-1];  // 1 bit valid
+    logic            [1:0] bht_btb_state     [0:BHT_BTB_SIZE-1];  // 2 bits for states
+    logic [DATA_WIDTH-1:0] bht_btb_target_pc [0:BHT_BTB_SIZE-1];  // 32 bits for predicted PC
+    
+    logic                  bht_btb_valid_data;                          // for read and write in BHT, BTB valid
+    logic            [1:0] bht_btb_state_data;                          // for read and write in BHT, BTB state
+    logic [DATA_WIDTH-1:0] bht_btb_target_pc_data;                      // for read and write in BHT, BTB target pc
+
+    logic [ADDR_WIDTH-1:0] bht_btb_addr;
+
+    assign bht_btb_addr           = pc[ADDR_WIDTH+1:2];
+    assign bht_btb_valid_data     = bht_btb_valid[bht_btb_addr];
+    assign bht_btb_state_data     = bht_btb_state[bht_btb_addr];
+    assign bht_btb_target_pc_data = bht_btb_target_pc[bht_btb_addr];
+
+    logic [DATA_WIDTH-1:0] pc8;
+    logic [ADDR_WIDTH-1:0] pc8_addr;
+
+    assign pc8 = pc + 32'd8;
+    assign pc8_addr = pc8[ADDR_WIDTH+1:2];
+
+    logic [DATA_WIDTH-1:0] jal_imm, jalr_imm;
+
+    // creating sync signals
+    always_ff @ (posedge clk, negedge arst_n)
+    begin
+        if (~arst_n)
+        begin
+            is_branch_d  <= 1'b0;
+            is_branch_dd <= 1'b0;
+        end
+        else
+        begin
+            is_branch_d  <= is_conditional_branch;
+            is_branch_dd <= is_branch_d;
+        end
+    end
+
+    // update BHT and BTB
+    always_ff @ (negedge clk, negedge arst_n)
+    begin
+        if (~arst_n)
+        begin
+            for (int i=0; i<BHT_BTB_SIZE; i++)     bht_btb_valid[i] <= 1'b0;
+            for (int i=0; i<BHT_BTB_SIZE; i++)     bht_btb_state[i] <= WEAKLY_NOT_TAKEN;
+        end
+        else if (is_branch_dd)
+        begin
+            case({bht_btb_state_data, br_taken})
+                {WEAKLY_TAKEN, 1'b1}: bht_btb_state[bht_btb_addr] <= STRONGLY_TAKEN;
+                {WEAKLY_TAKEN, 1'b0}: bht_btb_state[bht_btb_addr] <= WEAKLY_NOT_TAKEN;
+
+                {STRONGLY_TAKEN, 1'b1}: bht_btb_state[bht_btb_addr] <= STRONGLY_TAKEN;
+                {STRONGLY_TAKEN, 1'b0}: bht_btb_state[bht_btb_addr] <= WEAKLY_TAKEN;
+                
+                {WEAKLY_NOT_TAKEN, 1'b1}: bht_btb_state[bht_btb_addr] <= WEAKLY_TAKEN;
+                {WEAKLY_NOT_TAKEN, 1'b0}: bht_btb_state[bht_btb_addr] <= STRONGLY_NOT_TAKEN;
+                
+                {STRONGLY_NOT_TAKEN, 1'b1}: bht_btb_state[bht_btb_addr] <= WEAKLY_NOT_TAKEN;
+                {STRONGLY_NOT_TAKEN, 1'b0}: bht_btb_state[bht_btb_addr] <= STRONGLY_NOT_TAKEN;
+            endcase
+            // predict_pc <= bht_btb_target_pc_data;
+        end
+    end
+
+    always_ff @ (negedge clk, negedge arst_n)
+    begin
+        if (~arst_n)
+        begin
+            for (int i=0; i<BHT_BTB_SIZE; i++) bht_btb_target_pc[i] <= `RESET_PC;
+        end
+        else if (is_branch_dd && br_taken)
+        begin
+            bht_btb_target_pc[bht_btb_addr] <= br_target;
+        end
+    end
+
+    assign jal_imm = {{11{inst_in[31]}}, inst_in[31], inst_in[19:12], inst_in[20], inst_in[30:21], 1'b0};
+    assign jalr_imm = {{20{inst_in[31]}}, inst_in[31:20]};
+
+    always_comb
+    begin
+        if (is_jal)
+        begin
+            predict_taken = is_branch_d ? 1'b0 : 1'b1;   // because conditional branch has not been resolved yet
+            predict_pc    = pc + jal_imm;
+        end
+        // else if (is_jalr)
+        // begin
+        //     predict_taken = is_branch_d ? 1'b0 : 1'b1;   // because conditional branch has not been resolved yet
+        //     predict_pc    = pc + jalr_imm;
+        // end
+        else if (is_conditional_branch)
+        begin
+            predict_taken = (bht_btb_state[pc8_addr] == WEAKLY_TAKEN) | (bht_btb_state[pc8_addr] == STRONGLY_TAKEN);
+            predict_pc    = bht_btb_target_pc[pc8_addr];
+        end
+        else
+        begin
+            predict_taken = 1'b0;
+            predict_pc    = `RESET_PC;
+        end
+    end
+
+    // register pc for using in PC selection process in case of conditional branches
+    always_ff @ (posedge clk, negedge arst_n)
+    begin
+        if (~arst_n) pc_reg <= `RESET_PC;
+        else if (is_conditional_branch) pc_reg <= pc;
+    end
+endmodule: bpu

--- a/verif/Makefile_verilator
+++ b/verif/Makefile_verilator
@@ -1,0 +1,17 @@
+
+BUILD_DIR = verilator_sim/
+TOPLEVEL = tb_pakrv
+
+compile:
+	@verilator --Mdir $(BUILD_DIR) -cc ../src/*.sv ../sub/components/src/*.sv src/tb_pakrv.sv -I../include -I../sub/components/include --top-module $(TOPLEVEL) --exe src/tb_pakrv.cpp --trace --trace-structs --timing -Wno-WIDTHTRUNC -Wno-WIDTHEXPAND -Wno-TIMESCALEMOD
+
+make_executable:
+	@make -C $(BUILD_DIR) -f V$(TOPLEVEL).mk
+
+simulate:
+	@./$(BUILD_DIR)/./V$(TOPLEVEL)
+
+all: compile make_executable simulate
+
+clean:
+	@rm -rf $(BUILD_DIR)

--- a/verif/src/tb_pakrv.sv
+++ b/verif/src/tb_pakrv.sv
@@ -1,7 +1,7 @@
 `timescale 1 ns / 100 ps
 
 // this test-bench has inputs ports because
-// to do simulation using verilator, we need a cpp test-bench as well
+// to do simulation using verilator, we need a cpp test-bench as well just to generate clock and reset
 
 `define MEM        i_core_top.i_mem
 
@@ -15,7 +15,6 @@ module tb_pakrv #(
     string  instructions;
     integer time_out;
     integer signature_fp;
-    integer dummy_fp;
     
     core_top # (
         .DATA_WIDTH ( DATA_WIDTH )
@@ -41,11 +40,8 @@ module tb_pakrv #(
         $finish;
     end
 
-    integer count;
-
     initial
     begin
-        count = 0;
         forever
         begin
             @ (posedge clk);
@@ -54,14 +50,11 @@ module tb_pakrv #(
             if (`MEM.write_en && `MEM.addr == 32'h8E00_0000)
             begin
                 $fwrite(signature_fp, "%h\n", `MEM.data_in);
-                count += 1;
             end
 
             // HALT condition in the case of compliance testing
             if (`MEM.write_en && `MEM.addr == 32'h8F00_0000)
             begin
-                $fwrite(dummy_fp, "%0d\n", count);
-                $display("\033[33mNumber of cycles spent on the program: %0d.\033[0m", count);
                 $finish;
             end
         end
@@ -70,7 +63,6 @@ module tb_pakrv #(
     initial
     begin
         signature_fp = $fopen("DUT-pakrv.signature", "w"); // signature dumping file
-        dummy_fp     = $fopen("tempo.txt", "a");
         if (signature_fp == 0)
         begin
             $display("Error opening file for signature dumping");

--- a/verif/src/tb_pakrv.sv
+++ b/verif/src/tb_pakrv.sv
@@ -15,6 +15,7 @@ module tb_pakrv #(
     string  instructions;
     integer time_out;
     integer signature_fp;
+    integer clk_cycles_counter_fp;
     
     core_top # (
         .DATA_WIDTH ( DATA_WIDTH )
@@ -40,6 +41,21 @@ module tb_pakrv #(
         $finish;
     end
 
+    // count number of clock cycles the program took
+    integer number_of_cycles;
+    initial
+    begin
+        number_of_cycles = 0;
+        forever
+        begin
+            if (arst_n)
+            begin
+                @(posedge clk);
+                number_of_cycles += 1;
+            end
+        end
+    end
+
     initial
     begin
         forever
@@ -55,6 +71,8 @@ module tb_pakrv #(
             // HALT condition in the case of compliance testing
             if (`MEM.write_en && `MEM.addr == 32'h8F00_0000)
             begin
+                $fwrite(clk_cycles_counter_fp, "%150s ", instructions);
+                $fwrite(clk_cycles_counter_fp, "%20d\n", number_of_cycles);
                 $finish;
             end
         end
@@ -62,12 +80,20 @@ module tb_pakrv #(
 
     initial
     begin
-        signature_fp = $fopen("DUT-pakrv.signature", "w"); // signature dumping file
+        signature_fp          = $fopen("DUT-pakrv.signature", "w"); // signature dumping file
+        clk_cycles_counter_fp = $fopen("clk_cycles.cycles", "a");
+
         if (signature_fp == 0)
         begin
-            $display("Error opening file for signature dumping");
+            $display("Error opening file DUT-pakrv.signature for signature dumping");
             $finish;
         end
+        if (clk_cycles_counter_fp == 0)
+        begin
+            $display("Error opening file clk_cycles.cycles for signature dumping");
+            $finish;
+        end
+
     end
 
     initial

--- a/verif/src/tb_pakrv.sv
+++ b/verif/src/tb_pakrv.sv
@@ -15,6 +15,7 @@ module tb_pakrv #(
     string  instructions;
     integer time_out;
     integer signature_fp;
+    integer dummy_fp;
     
     core_top # (
         .DATA_WIDTH ( DATA_WIDTH )
@@ -40,8 +41,11 @@ module tb_pakrv #(
         $finish;
     end
 
+    integer count;
+
     initial
     begin
+        count = 0;
         forever
         begin
             @ (posedge clk);
@@ -50,11 +54,14 @@ module tb_pakrv #(
             if (`MEM.write_en && `MEM.addr == 32'h8E00_0000)
             begin
                 $fwrite(signature_fp, "%h\n", `MEM.data_in);
+                count += 1;
             end
 
             // HALT condition in the case of compliance testing
             if (`MEM.write_en && `MEM.addr == 32'h8F00_0000)
             begin
+                $fwrite(dummy_fp, "%0d\n", count);
+                $display("\033[33mNumber of cycles spent on the program: %0d.\033[0m", count);
                 $finish;
             end
         end
@@ -63,6 +70,7 @@ module tb_pakrv #(
     initial
     begin
         signature_fp = $fopen("DUT-pakrv.signature", "w"); // signature dumping file
+        dummy_fp     = $fopen("tempo.txt", "a");
         if (signature_fp == 0)
         begin
             $display("Error opening file for signature dumping");


### PR DESCRIPTION
Following changes have been made:

1. Parameterizable 2-bit dynamic branch predictor (with not history tracking) added. A parameter `SUPPORT_BRANCH_PREDICTION` is used for this purpose. If it is assigned 1, then branch predictor will get activated. We can update this parameter in the file `<main_directory>/src/core_top.sv` for now.
2. Cleanup of `fetch stage (if_stage.sv)`. Ports are moved to structs for sophisticated usage